### PR TITLE
Add arialinter

### DIFF
--- a/docs/ingredients/angular-templates.md
+++ b/docs/ingredients/angular-templates.md
@@ -18,6 +18,10 @@ new Lentil({
     htmlhint: {
         'doctype-first': false
     },
+    arialinter: {
+        level: 'AA',
+        templates: true
+    },
     angularTemplatecache: {
       module: 'lentil.{name}'.assign({
           name: options.name

--- a/lib/ingredients/angularTemplates.js
+++ b/lib/ingredients/angularTemplates.js
@@ -19,6 +19,10 @@ module.exports = (function() {
                 'doctype-first': false
             })))
             .pipe(plugins.htmlhint.reporter('htmlhint-stylish'))
+            .pipe(plugins.arialinter(config.mergeDefault('plugins.arialinter', {
+                level: 'AA',
+                templates: true
+            })))
             .pipe(plugins.angularTemplatecache(config.mergeDefault('plugins.angularTemplatecache', {
                 module: 'lentil.{name}'.assign({
                     name: options.name

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp": "^3.9.0",
     "gulp-add-src": "^0.2.0",
     "gulp-angular-templatecache": "^1.8.0",
+    "gulp-arialinter": "0.0.1",
     "gulp-concat": "^2.6.0",
     "gulp-csso": "^1.0.1",
     "gulp-eslint": "^1.0.0",


### PR DESCRIPTION
Adding the `gulp-arialinter` plugin. (https://github.com/globant-ui/arialinter)

The default configuration values will be:

```javascript
{
  level: 'AA',
  templates: true
}
```