### PR TITLE
Fix deploy asynchronisity.

### DIFF
--- a/lib/ingredients/angular.js
+++ b/lib/ingredients/angular.js
@@ -8,7 +8,7 @@ module.exports = (function() {
         var TaskRunner = require('../TaskRunner');
 
         return function parseAngular(done) {
-            return TaskRunner.ingredients.angularTemplates(config, options)()
+            TaskRunner.ingredients.angularTemplates(config, options)()
                 .then(function(templateFile) {
                     var paths = TaskRunner.paths.angular(config, options);
 
@@ -35,9 +35,9 @@ module.exports = (function() {
                         if (templateFile && fs.existsSync(templateFile)) {
                             fs.unlinkSync(templateFile);
                         }
-                    });
 
-                    return compilePipe;
+                        done();
+                    });
                 });
         }
     };


### PR DESCRIPTION
The trigger for the separate angular file generations for done, was being triggered too early. This fixes it, by placing the `done()` on the last resolve.