### PR TITLE
Add quick deploy task

### DIFF
--- a/lib/Deployer.js
+++ b/lib/Deployer.js
@@ -14,6 +14,19 @@ module.exports = (function() {
         TaskContainer.add(this.gulp, 'deploy', TaskRunner.ingredients.deploy(this.gulp, config), this.basicTasks);
     };
 
+    Deployer.prototype.quickDeployTask = function() {
+        TaskContainer.add(this.gulp, 'quick-deploy', function(done) {
+            global.quickDeploy = true;
+            this.gulp.start('deploy')
+                .on('end', function() {
+                    global.quickDeploy = false;
+                    done();
+                });
+        }.bind({
+            gulp: this.gulp
+        }));
+    };
+
     return Deployer;
 
 }());

--- a/lib/Lentil.js
+++ b/lib/Lentil.js
@@ -71,6 +71,7 @@ module.exports = (function() {
 
         var deployer = new Deployer(this.gulp, basicTasks);
         deployer.deployTask(this.config);
+        deployer.quickDeployTask();
 
         var tester = new Tester(this.gulp);
         tester.testTask(this.config);

--- a/lib/ingredients/angular.js
+++ b/lib/ingredients/angular.js
@@ -11,18 +11,22 @@ module.exports = (function() {
                 .then(function(templateFile) {
                     var paths = TaskRunner.paths.angular(config, options);
 
-                    var compilePipe = gulp.src(paths)
-                    .pipe(plugins.eslint(config.mergeDefault('plugins.eslint', {
-                        plugins: [
-                            'angular'
-                        ],
-                        rules: {
-                            'angular/module-getter': 0,
-                            'angular/module-setter': 0
-                        }
-                    })))
-                    .pipe(plugins.eslint.format('stylish'))
-                    .pipe(plugins.addSrc.append(templateFile))
+                    var compilePipe = gulp.src(paths);
+
+                    if (!global.quickDeploy) {
+                        compilePipe.pipe(plugins.eslint(config.mergeDefault('plugins.eslint', {
+                            plugins: [
+                                'angular'
+                            ],
+                            rules: {
+                                'angular/module-getter': 0,
+                                'angular/module-setter': 0
+                            }
+                        })))
+                        .pipe(plugins.eslint.format('stylish'));
+                    }
+
+                    compilePipe.pipe(plugins.addSrc.append(templateFile))
                     .pipe(plugins.sourcemaps.init())
                     .pipe(plugins.ngAnnotate(config.mergeDefault('plugins.ngAnnotate')))
                     .pipe(plugins.concat('{name}-{task}.js'.assign({

--- a/lib/ingredients/angularTemplates.js
+++ b/lib/ingredients/angularTemplates.js
@@ -13,12 +13,16 @@ module.exports = (function() {
             var TMP_FOLDER = config.get('paths.tmp');
             var ROOT_PREFIX = config.get('paths.rootPrefix');
 
-            var compilePipe = gulp.src(TaskRunner.paths.angularTemplates(config, options))
-            .pipe(plugins.htmlhint(config.mergeDefault('plugins.htmlhint', {
-                'doctype-first': false
-            })))
-            .pipe(plugins.htmlhint.reporter('htmlhint-stylish'))
-            .pipe(plugins.angularTemplatecache(config.mergeDefault('plugins.angularTemplatecache', {
+            var compilePipe = gulp.src(TaskRunner.paths.angularTemplates(config, options));
+
+            if (!global.quickDeploy) {
+                compilePipe.pipe(plugins.htmlhint(config.mergeDefault('plugins.htmlhint', {
+                    'doctype-first': false
+                })))
+                .pipe(plugins.htmlhint.reporter('htmlhint-stylish'));
+            }
+
+            compilePipe.pipe(plugins.angularTemplatecache(config.mergeDefault('plugins.angularTemplatecache', {
                 module: 'lentil.{name}'.assign({
                     name: options.name
                 }),

--- a/lib/ingredients/deploy.js
+++ b/lib/ingredients/deploy.js
@@ -13,11 +13,15 @@ module.exports = (function() {
             })))
             .pipe(plugins.rename(config.mergeDefault('plugins.rename', {
                 suffix: '.min'
-            })))
-            .pipe(plugins.size(config.mergeDefault('plugins.size', {
-                showFiles: true
-            })))
-            .pipe(gulp.dest(config.get('paths.dist')))
+            })));
+
+            if (!global.quickDeploy) {
+                jsCompilePipe.pipe(plugins.size(config.mergeDefault('plugins.size', {
+                    showFiles: true
+                })))
+            }
+
+            jsCompilePipe.pipe(gulp.dest(config.get('paths.dist')))
             .on('end', function() {
                 var cssCompilePipe = gulp.src([
                     config.get('paths.dist') + '/**/*.css',
@@ -32,11 +36,15 @@ module.exports = (function() {
                 })))
                 .pipe(plugins.rename(config.mergeDefault('plugins.rename', {
                     suffix: '.min'
-                })))
-                .pipe(plugins.size(config.mergeDefault('plugins.size', {
-                    showFiles: true
-                })))
-                .pipe(gulp.dest(config.get('paths.dist')))
+                })));
+
+                if (!global.quickDeploy) {
+                    cssCompilePipe.pipe(plugins.size(config.mergeDefault('plugins.size', {
+                        showFiles: true
+                    })));
+                }
+
+                cssCompilePipe.pipe(gulp.dest(config.get('paths.dist')))
                 .on('end', function() {
                     done();
                 });

--- a/lib/ingredients/js.js
+++ b/lib/ingredients/js.js
@@ -5,19 +5,25 @@ module.exports = (function() {
     return function(gulp, config, options) {
         var TaskRunner = require('../TaskRunner');
 
-        return function parseJs() {
-            var compilePipe = gulp.src(TaskRunner.paths.js(config, options))
-            .pipe(plugins.eslint('./eslintconfig.json'))
-            .pipe(plugins.eslint.format('stylish'))
-            .pipe(plugins.sourcemaps.init())
+        return function parseJs(done) {
+            var compilePipe = gulp.src(TaskRunner.paths.js(config, options));
+
+            if (!global.quickDeploy) {
+                compilePipe
+                .pipe(plugins.eslint('./eslintconfig.json'))
+                .pipe(plugins.eslint.format('stylish'));
+            }
+
+            compilePipe.pipe(plugins.sourcemaps.init())
             .pipe(plugins.concat('{name}-{task}.js'.assign({
                 name: options.name,
                 task: 'js'
             })))
             .pipe(plugins.sourcemaps.write())
-            .pipe(gulp.dest(config.get('paths.dist')));
-
-            return compilePipe;
+            .pipe(gulp.dest(config.get('paths.dist')))
+            .on('end', function() {
+                done();
+            });
         };
     };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/hellofresh/lentil",
   "dependencies": {
     "eslint-plugin-angular": "^0.13.0",
+    "event-stream": "^3.3.2",
     "gulp": "^3.9.0",
     "gulp-add-src": "^0.2.0",
     "gulp-angular-templatecache": "^1.8.0",


### PR DESCRIPTION
Adding a quick deploy task, `gulp quick-deploy`, that will skip all linting and just deploy files.