### PR TITLE
Make command line shorter

### DIFF
--- a/bin/lentil.js
+++ b/bin/lentil.js
@@ -63,7 +63,7 @@ if (cluster.isMaster) {
         deploy: argv.deploy,
     });
 
-    const commands = commandsRunner.seedCommands(numCpus, argv, config);
+    const commands = commandsRunner.seedCommands(numCpus, argv);
 
     Promise.all(
         commands.filter(
@@ -104,7 +104,7 @@ if (cluster.isMaster) {
     const rawCommands = JSON.parse(process.env.commands);
 
     const deferredArray = rawCommands.map((rawCommand) => {
-        const command = Command.ofRaw(rawCommand);
+        const command = Command.ofRaw(rawCommand, config);
 
         return command.run();
     });

--- a/lib/Command.js
+++ b/lib/Command.js
@@ -19,8 +19,8 @@ class Command {
         return lentil.run(this.moduleName, this.taskName, this.options);
     }
 
-    static ofRaw(rawCommand) {
-        return new Command(rawCommand.moduleName, rawCommand.taskName, rawCommand.options, rawCommand.config);
+    static ofRaw(rawCommand, config) {
+        return new Command(rawCommand.moduleName, rawCommand.taskName, rawCommand.options, config);
     }
 }
 

--- a/lib/CommandsRunner.js
+++ b/lib/CommandsRunner.js
@@ -7,13 +7,13 @@ class CommandsRunner {
         this.options = options;
     }
 
-    seedCommands(numCpus = 1, options = {}, config = {}) {
+    seedCommands(numberOfClusters = 1, options = {}) {
         const commands = [];
 
         for (let moduleName of this.modules) {
             for (let taskName of this.tasks) {
                 commands.push(
-                    new Command(moduleName, taskName, options, config)
+                    new Command(moduleName, taskName, options)
                 );
 
 
@@ -24,8 +24,7 @@ class CommandsRunner {
                             taskName,
                             {
                                 minify: !options.minify,
-                            },
-                            config
+                            }
                         )
                     );
                 }
@@ -36,17 +35,17 @@ class CommandsRunner {
             commands.push(
                 new Command(null, 'libs', {
                     minify: true,
-                }, config)
+                })
             );
 
             commands.push(
                 new Command(null, 'libs', {
                     minify: false,
-                }, config)
+                })
             );
         }
 
-        return commands.inGroups(numCpus);
+        return commands.inGroups(numberOfClusters);
     }
 }
 


### PR DESCRIPTION
The command that was being sent to the lower clusters was becoming too long, because of the underlying config object that was being passed around unnecessarily.